### PR TITLE
Revert back pycryptodome to pip version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ RUN apt-get update \
        doxygen \
        python3 \
        python3-pip \
-       python3-pycryptodome \
     && rm -fr /var/libapt/lists/*
+
+# Install pycryptodome package needed for scratchpad image generation
+RUN pip3 install pycryptodome==3.9.7
 
 WORKDIR /home/${user}
 


### PR DESCRIPTION
The apt package install pycryptodomex that is not the same on API point of view. Code must be modified first