### PR TITLE
Update pycryptodome version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update \
     && rm -fr /var/libapt/lists/*
 
 # Install pycryptodome package needed for scratchpad image generation
-RUN pip3 install pycryptodome==3.9.7
+RUN pip3 install pycryptodome==3.16.0
 
 WORKDIR /home/${user}
 


### PR DESCRIPTION
PyCryptodome v3.9.7 doesn't have the required elliptic curve algorithms to be able to support the new signed scratchpad format. This commit updates the pycryptodome Python package version to the latest available (v3.16.0).