### PR TITLE
Add tool to generate compile_commands.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN apt-get update \
 # Install pycryptodome package needed for scratchpad image generation
 RUN pip3 install pycryptodome==3.16.0
 
+# Tool to generate clang's "compile_command.json" for make-based projects
+RUN pip3 install compiledb==0.10.1
+
 WORKDIR /home/${user}
 
 # Install Arm compiler


### PR DESCRIPTION
[Clang's compile command database](https://clang.llvm.org/docs/JSONCompilationDatabase.html) is used by a multitude of tool to discover the parameters a certain file was compiled with. Tools that support `compile_commands.json` as an input include industry standard tools like `Visual Studio Code` and `clang-tidy`.

With the [compiledb](https://github.com/nickdiego/compiledb) command available in the build container the `compile_commands.json` database can effortlessly be generated by just prepending `compiledb` infront of the make call for example 

```shell
compiledb make app_name=custom_app target_board=pca10040
```